### PR TITLE
new compat layers for software.nessi.no/2023.09

### DIFF
--- a/.github/workflows/pilot_repo.yml
+++ b/.github/workflows/pilot_repo.yml
@@ -1,5 +1,5 @@
 # documentation: https://help.github.com/en/articles/workflow-syntax-for-github-actions
-name: Tests for EESSI pilot repo
+name: Tests for NESSI pilot repo
 on:
   push:
   pull_request:
@@ -17,7 +17,7 @@ jobs:
       matrix:
         EESSI_VERSION:
         # note: use string quotes here, to avoid values being interpreted as floating point values...
-        - '2022.11'
+        - '2023.06'
         EESSI_ARCH:
         - aarch64
         - x86_64
@@ -38,11 +38,11 @@ jobs:
         - name: Mount EESSI CernVM-FS pilot repository
           uses: cvmfs-contrib/github-action-cvmfs@d4641d0d591c9a5c3be23835ced2fb648b44c04b # v3.1
           with:
-              cvmfs_config_package: https://github.com/EESSI/filesystem-layer/releases/download/latest/cvmfs-config-eessi_latest_all.deb
+              cvmfs_config_package: https://github.com/NorESSI/filesystem-layer/releases/download/latest/cvmfs-config-nessi_latest_all.deb
               cvmfs_http_proxy: DIRECT
               cvmfs_repositories: pilot.nessi.no
 
-        - name: Check compat layer in EESSI pilot repository
+        - name: Check compat layer in NESSI pilot repository
           env:
               EPREFIX: /cvmfs/pilot.nessi.no/versions/${{matrix.EESSI_VERSION}}/compat/linux/${{matrix.EESSI_ARCH}}
           run: |

--- a/.github/workflows/pilot_repo.yml
+++ b/.github/workflows/pilot_repo.yml
@@ -1,5 +1,5 @@
 # documentation: https://help.github.com/en/articles/workflow-syntax-for-github-actions
-name: Tests for NESSI pilot repo
+name: Tests for software.nessi.no
 on:
   push:
   pull_request:
@@ -17,7 +17,7 @@ jobs:
       matrix:
         EESSI_VERSION:
         # note: use string quotes here, to avoid values being interpreted as floating point values...
-        - '2023.06'
+        - '2023.09'
         EESSI_ARCH:
         - aarch64
         - x86_64
@@ -40,19 +40,19 @@ jobs:
           with:
               cvmfs_config_package: https://github.com/NorESSI/filesystem-layer/releases/download/latest/cvmfs-config-nessi_latest_all.deb
               cvmfs_http_proxy: DIRECT
-              cvmfs_repositories: pilot.nessi.no
+              cvmfs_repositories: software.nessi.no
 
         - name: Check compat layer in NESSI pilot repository
           env:
-              EPREFIX: /cvmfs/pilot.nessi.no/versions/${{matrix.EESSI_VERSION}}/compat/linux/${{matrix.EESSI_ARCH}}
+              EPREFIX: /cvmfs/software.nessi.no/versions/${{matrix.EESSI_VERSION}}/compat/linux/${{matrix.EESSI_ARCH}}
           run: |
               # trigger automount
-              echo '>> ls /cvmfs/pilot.nessi.no'
-              ls /cvmfs/pilot.nessi.no
+              echo '>> ls /cvmfs/software.nessi.no'
+              ls /cvmfs/software.nessi.no
 
               # check which Stratum 1 we're connected to
-              echo '>> cvmfs_config stat -v pilot.nessi.no'
-              cvmfs_config stat -v pilot.nessi.no
+              echo '>> cvmfs_config stat -v software.nessi.no'
+              cvmfs_config stat -v software.nessi.no
 
               echo '>> ls ${EPREFIX}/startprefix'
               ls ${EPREFIX}/startprefix

--- a/.github/workflows/pilot_repo.yml
+++ b/.github/workflows/pilot_repo.yml
@@ -17,10 +17,9 @@ jobs:
       matrix:
         EESSI_VERSION:
         # note: use string quotes here, to avoid values being interpreted as floating point values...
-        - '2021.12'
+        - '2022.11'
         EESSI_ARCH:
         - aarch64
-        - ppc64le
         - x86_64
         EESSI_OS:
         - linux
@@ -41,19 +40,19 @@ jobs:
           with:
               cvmfs_config_package: https://github.com/EESSI/filesystem-layer/releases/download/latest/cvmfs-config-eessi_latest_all.deb
               cvmfs_http_proxy: DIRECT
-              cvmfs_repositories: pilot.eessi-hpc.org
+              cvmfs_repositories: pilot.nessi.no
 
         - name: Check compat layer in EESSI pilot repository
           env:
-              EPREFIX: /cvmfs/pilot.eessi-hpc.org/versions/${{matrix.EESSI_VERSION}}/compat/linux/${{matrix.EESSI_ARCH}}
+              EPREFIX: /cvmfs/pilot.nessi.no/versions/${{matrix.EESSI_VERSION}}/compat/linux/${{matrix.EESSI_ARCH}}
           run: |
               # trigger automount
-              echo '>> ls /cvmfs/pilot.eessi-hpc.org'
-              ls /cvmfs/pilot.eessi-hpc.org
+              echo '>> ls /cvmfs/pilot.nessi.no'
+              ls /cvmfs/pilot.nessi.no
 
               # check which Stratum 1 we're connected to
-              echo '>> cvmfs_config stat -v pilot.eessi-hpc.org'
-              cvmfs_config stat -v pilot.eessi-hpc.org
+              echo '>> cvmfs_config stat -v pilot.nessi.no'
+              cvmfs_config stat -v pilot.nessi.no
 
               echo '>> ls ${EPREFIX}/startprefix'
               ls ${EPREFIX}/startprefix

--- a/ansible/playbooks/README.md
+++ b/ansible/playbooks/README.md
@@ -39,7 +39,6 @@ Before running the playbook, make sure the following settings are correct, and o
 | gentoo_git_repo | URL to the git repository of the (official) Gentoo ebuild repository |
 | gentoo_git_commit | Git commit hash of the Gentoo ebuild repository to be used for the bootstrap |
 | prefix_required_space | Minimal amount of disk space that is required for the Gentoo Prefix bootstrap |
-| prefix_default_gcc | GCC compiler version to use as default compiler in Gentoo Prefix installation |
 | prefix_user_defined_trusted_dirs | List of paths to the user defined trusted dirs for glibc |
 | prefix_mask_packages | Contents of a [package.mask file](https://wiki.gentoo.org/wiki//etc/portage/package.mask) that should be used during the bootstrap |
 | prefix_unmask_packages | Contents of a [package.unmask file](https://wiki.gentoo.org/wiki//etc/portage/package.unmask) that should be used during the bootstrap |

--- a/ansible/playbooks/roles/compatibility_layer/defaults/main.yml
+++ b/ansible/playbooks/roles/compatibility_layer/defaults/main.yml
@@ -31,7 +31,7 @@ prefix_mask_packages: |
   # - older versions of Rust (see https://github.com/EESSI/software-layer/issues/257)
   # - older versions of cryptograhy in Python (see https://github.com/EESSI/software-layer/issues/258)
   >=dev-libs/openssl-3
-#prefix_unmask_packages: |
+prefix_unmask_packages: # |
 #  # unmask older GCC to make it installable
 #  # =sys-devel/gcc-9*
 prefix_bootstrap_use_flags: |

--- a/ansible/playbooks/roles/compatibility_layer/defaults/main.yml
+++ b/ansible/playbooks/roles/compatibility_layer/defaults/main.yml
@@ -1,14 +1,14 @@
 # Defaults file for the compatibility layer role.
 ---
-eessi_version: "2023.06"
+eessi_version: "2023.09"
 
 custom_overlays:
   - name: eessi
     source: git
-    url: https://github.com/EESSI/gentoo-overlay.git
+    url: https://github.com/NorESSI/gentoo-overlay.git
     eclass-overrides: true
 
-cvmfs_repository: pilot.nessi.no
+cvmfs_repository: software.nessi.no
 
 gentoo_prefix_path: /cvmfs/{{ cvmfs_repository }}/versions/{{ eessi_version }}/compat/{{ eessi_host_os }}/{{ eessi_host_arch }}
 

--- a/ansible/playbooks/roles/compatibility_layer/defaults/main.yml
+++ b/ansible/playbooks/roles/compatibility_layer/defaults/main.yml
@@ -5,7 +5,7 @@ eessi_version: "2023.06"
 custom_overlays:
   - name: eessi
     source: git
-    url: https://github.com/eessi/gentoo-overlay.git
+    url: https://github.com/EESSI/gentoo-overlay.git
     eclass-overrides: true
 
 cvmfs_repository: pilot.nessi.no
@@ -21,20 +21,19 @@ gentoo_git_repo: https://github.com/gentoo/gentoo.git
 # June 8 (aab8473aa90e0287553b3348a5c5b17872df4b7b) commit that was current when fetching luaposix
 gentoo_git_commit: aab8473aa90e0287553b3348a5c5b17872df4b7b
 prefix_required_space: 15 GB
-prefix_default_gcc: 9.5.0
 prefix_user_defined_trusted_dirs:
   - "/cvmfs/{{ cvmfs_repository }}/host_injections/{{ eessi_version }}/compat/{{ eessi_host_os }}/{{ eessi_host_arch }}/lib"
 prefix_mask_packages: |
-  # stick to GCC 9.x; using a too recent compiler in the compat layer complicates stuff in the software layer,
+  # stick to GCC 10.x; using a too recent compiler in the compat layer complicates stuff in the software layer,
   # see for example https://github.com/EESSI/software-layer/issues/151
-  >=sys-devel/gcc-10
+  >=sys-devel/gcc-11
   # mask OpenSSL 3.x, stick to OpenSSL 1.1.x for now to avoid problems with:
   # - older versions of Rust (see https://github.com/EESSI/software-layer/issues/257)
   # - older versions of cryptograhy in Python (see https://github.com/EESSI/software-layer/issues/258)
   >=dev-libs/openssl-3
-prefix_unmask_packages: |
-  # unmask older GCC to make it installable
-  =sys-devel/gcc-9*
+#prefix_unmask_packages: |
+#  # unmask older GCC to make it installable
+#  # =sys-devel/gcc-9*
 prefix_bootstrap_use_flags: |
   # make sure that gold linker is installed with binutils
   sys-devel/binutils gold

--- a/ansible/playbooks/roles/compatibility_layer/defaults/main.yml
+++ b/ansible/playbooks/roles/compatibility_layer/defaults/main.yml
@@ -8,7 +8,7 @@ custom_overlays:
     url: https://github.com/eessi/gentoo-overlay.git
     eclass-overrides: true
 
-cvmfs_repository: pilot.eessi-hpc.org
+cvmfs_repository: pilot.nessi.no
 
 gentoo_prefix_path: /cvmfs/{{ cvmfs_repository }}/versions/{{ eessi_version }}/compat/{{ eessi_host_os }}/{{ eessi_host_arch }}
 

--- a/ansible/playbooks/roles/compatibility_layer/defaults/main.yml
+++ b/ansible/playbooks/roles/compatibility_layer/defaults/main.yml
@@ -31,9 +31,9 @@ prefix_mask_packages: |
   # - older versions of Rust (see https://github.com/EESSI/software-layer/issues/257)
   # - older versions of cryptograhy in Python (see https://github.com/EESSI/software-layer/issues/258)
   >=dev-libs/openssl-3
-prefix_unmask_packages: # |
-#  # unmask older GCC to make it installable
-#  # =sys-devel/gcc-9*
+prefix_unmask_packages: |
+  # unmask older GCC to make it installable
+  =sys-devel/gcc-10*
 prefix_bootstrap_use_flags: |
   # make sure that gold linker is installed with binutils
   sys-devel/binutils gold

--- a/ansible/playbooks/roles/compatibility_layer/tasks/prefix_configuration.yml
+++ b/ansible/playbooks/roles/compatibility_layer/tasks/prefix_configuration.yml
@@ -15,6 +15,6 @@
 # when building older GCC versions with EasyBuild in the software layer.
 # (see https://github.com/EESSI/software-layer/issues/151).
 # Note: the selected GCC version must be installed (cfr. EESSI set in gentoo-overlay)
-- name: Make specific GCC version the default compiler
-  ansible.builtin.command: "{{ gentoo_prefix_path }}/usr/bin/gcc-config {{ prefix_default_gcc }}"
-  changed_when: false
+#- name: Make specific GCC version the default compiler
+#  ansible.builtin.command: "{{ gentoo_prefix_path }}/usr/bin/gcc-config {{ prefix_default_gcc }}"
+#  changed_when: false

--- a/ansible/playbooks/roles/compatibility_layer/tasks/prefix_configuration.yml
+++ b/ansible/playbooks/roles/compatibility_layer/tasks/prefix_configuration.yml
@@ -9,12 +9,3 @@
     state: present
   with_items: "{{ prefix_locales }}"
   notify: Generate locales
-
-# Set default compiler in compat layer.
-# We should not use the latest version of GCC here, since that will probably cause problems
-# when building older GCC versions with EasyBuild in the software layer.
-# (see https://github.com/EESSI/software-layer/issues/151).
-# Note: the selected GCC version must be installed (cfr. EESSI set in gentoo-overlay)
-#- name: Make specific GCC version the default compiler
-#  ansible.builtin.command: "{{ gentoo_prefix_path }}/usr/bin/gcc-config {{ prefix_default_gcc }}"
-#  changed_when: false

--- a/bot/build.sh
+++ b/bot/build.sh
@@ -81,9 +81,9 @@ host_arch=$(uname -m)
 eessi_arch=${cpu_target_arch:-${host_arch}}
 eessi_os=linux
 job_version=$(cfg_get_value "repository" "repo_version")
-eessi_version=${job_version:-2023.06}
+eessi_version=${job_version:-2023.09}
 job_repo=$(cfg_get_value "repository" "repo_name")
-eessi_repo=${job_repo:-pilot.eessi-hpc.org}
+eessi_repo=${job_repo:-software.eessi.io}
 tar_topdir=/cvmfs/${eessi_repo}/versions
 
 if [ "${eessi_arch}" != "${host_arch}" ]; then

--- a/bot/build.sh
+++ b/bot/build.sh
@@ -94,6 +94,7 @@ fi
 # option -k is used for retaining ${eessi_tmp}
 ./install_compatibility_layer.sh -a ${eessi_arch} -v ${eessi_version} -r ${eessi_repo} -g ${STORAGE} -k
 
+eessi_tmp=${STORAGE}
 # create tarball -> should go into a separate script when this is supported by the bot
 target_tgz=eessi-${eessi_version}-compat-linux-${eessi_arch}-$(date +%s).tar.gz
 if [ -d ${eessi_tmp}/${tar_topdir}/${eessi_version} ]; then

--- a/bot/build.sh
+++ b/bot/build.sh
@@ -97,11 +97,11 @@ fi
 eessi_tmp=${STORAGE}
 # create tarball -> should go into a separate script when this is supported by the bot
 target_tgz=eessi-${eessi_version}-compat-linux-${eessi_arch}-$(date +%s).tar.gz
-if [ -d ${eessi_tmp}/${tar_topdir}/${eessi_version} ]; then
-  echo ">> Creating tarball ${target_tgz} from ${eessi_tmp}/${tar_topdir}..."
-  tar cfvz ${target_tgz} -C ${eessi_tmp}/${tar_topdir} ${eessi_version}/compat/${eessi_os}/${eessi_arch}
+if [ -d ${eessi_tmp}${tar_topdir}/${eessi_version} ]; then
+  echo ">> Creating tarball ${target_tgz} from ${eessi_tmp}${tar_topdir}..."
+  tar cfvz ${target_tgz} -C ${eessi_tmp}${tar_topdir} ${eessi_version}/compat/${eessi_os}/${eessi_arch}
   echo ${target_tgz} created!
 else
-  echo "Directory ${eessi_tmp}/${tar_topdir}/${eessi_version} was not created, not creating tarball."
+  echo "Directory ${eessi_tmp}${tar_topdir}/${eessi_version} was not created, not creating tarball."
   exit 1
 fi

--- a/bot/check-result.sh
+++ b/bot/check-result.sh
@@ -1,0 +1,193 @@
+#!/bin/bash
+#
+# Script to check the result of building the EESSI compatibility layer.
+# Intended use is that it is called by a (batch) job running on a compute
+# node.
+#
+# This script is part of the EESSI compatibility layer, see
+# https://github.com/EESSI/compatibility-layer.git
+#
+# author: Thomas Roeblitz (@trz42)
+#
+# license: GPLv2
+#
+
+# ASSUMPTIONs:
+#  - working directory has been prepared by the bot with a checkout of a
+#    pull request (OR by some other means)
+#  - the working directory contains a directory 'cfg' where the main config
+#    file 'job.cfg' has been deposited
+#  - the directory may contain any additional files referenced in job.cfg
+
+# Example output
+# beginning of job output
+#### A compatibility layer for architecture x86_64 will be built.
+#### created new temporary storage at /srv/eessi-2023.04/TS/eessi.fjgC41DsgS
+#### Using /srv/eessi-2023.04/TS/eessi.fjgC41DsgS as temporary storage...
+#### RUNTIME='/usr/bin/apptainer'
+#### ESC[32musing runtime /usr/bin/apptainerESC[0m
+#### Executing ansible-playbook -e eessi_host_os=linux -e eessi_host_arch=x86_64 -e eessi_version=2023.04 -e cvmfs_repository=pilot.eessi-hpc.org /compatibility-layer/ansible/playbooks/install.yml in docker://ghcr.io/eessi/bootstrap-prefix:debian11, this will take a while.
+
+# good TASKs to check for
+#### TASK [compatibility_layer : Create Gentoo prefix path and log directory] *******
+#### changed: [localhost] => (item=/cvmfs/pilot.eessi-hpc.org/versions/2023.04/compat/linux/x86_64)
+#### changed: [localhost] => (item=/tmp/eessi-logs)
+#### 
+#### TASK [compatibility_layer : Add custom overlay configuration] ******************
+#### skipping: [localhost] => (item={'name': 'eessi', 'source': 'git', 'url': 'https://github.com/trz42/gentoo-overlay.git', 'eclass-overrides': True}) 
+#### skipping: [localhost]
+#### 
+#### TASK [compatibility_layer : Make configuration file with overlays that can override eclasses] ***
+#### ok: [localhost]
+#### 
+#### TASK [compatibility_layer : Sync the repositories] *****************************
+#### ok: [localhost]
+#### 
+#### TASK [compatibility_layer : Run Gentoo Prefix bootstrap stages 1-3 via /tmp/bootstrap-prefix.sh /cvmfs/pilot.eessi-hpc.org/versions/2023.04/compat/linux/x86_64 noninteractive] ***
+#### changed: [localhost]
+#### 
+#### TASK [compatibility_layer : Specify use flags before completing bootstrap] *****
+#### changed: [localhost]
+#### 
+#### TASK [compatibility_layer : Continue Gentoo Prefix bootstrap via /tmp/bootstrap-prefix.sh /cvmfs/pilot.eessi-hpc.org/versions/2023.04/compat/linux/x86_64 noninteractive] ***
+#### changed: [localhost]
+#### 
+#### TASK [compatibility_layer : (Re)install glibc with the user-defined-trusted-dirs option] ***
+#### skipping: [localhost]
+#### 
+#### TASK [compatibility_layer : Create portage env directory] **********************
+#### ok: [localhost]
+#### 
+#### TASK [compatibility_layer : Add env file for glibc to make sure the user-defined-trusted-dirs is always used] ***
+#### ok: [localhost]
+#### 
+#### TASK [compatibility_layer : Install package set ['eessi-2023.04-linux-x86_64']] ***
+#### ok: [localhost] => (item=eessi-2023.04-linux-x86_64)
+#### 
+#### TASK [compatibility_layer : Remove redundant packages] *************************
+#### ok: [localhost] => (item=dev-lang/go)
+#### ok: [localhost] => (item=dev-lang/go-bootstrap)
+#### 
+#### TASK [compatibility_layer : Run ReFrame tests] *********************************
+#### ok: [localhost]
+
+# end of job output
+#### PLAY RECAP *********************************************************************
+#### localhost                  : ok=17   changed=13   unreachable=0    failed=1    skipped=6    rescued=0    ignored=0   
+#### localhost                  : ok=38   changed=3    unreachable=0    failed=0    skipped=5    rescued=0    ignored=1   
+
+
+# stop as soon as something fails
+# set -e
+
+# TODO decide later what we actually need (scripts and cfg values)
+# source utils.sh and cfg_files.sh
+source scripts/utils.sh
+source scripts/cfg_files.sh
+
+# defaults
+export JOB_CFG_FILE="${JOB_CFG_FILE_OVERRIDE:=./cfg/job.cfg}"
+
+# check if ${JOB_CFG_FILE} exists
+if [[ ! -r "${JOB_CFG_FILE}" ]]; then
+    fatal_error "job config file (JOB_CFG_FILE=${JOB_CFG_FILE}) does not exist or not readable"
+fi
+echo "bot/check-result.sh: showing ${JOB_CFG_FILE} from compatibility-layer side"
+cat ${JOB_CFG_FILE}
+
+echo "bot/check-result.sh: obtaining configuration settings from '${JOB_CFG_FILE}'"
+cfg_load ${JOB_CFG_FILE}
+
+cpu_target_arch=$(cfg_get_value "architecture" "software_subdir" | cut -d/ -f1)
+host_arch=$(uname -m)
+eessi_arch=${cpu_target_arch:-${host_arch}}
+eessi_os=linux
+job_version=$(cfg_get_value "repository" "repo_version")
+eessi_version=${job_version:-2023.06}
+job_repo=$(cfg_get_value "repository" "repo_name")
+eessi_repo=${job_repo:-pilot.eessi-hpc.org}
+tar_topdir=/cvmfs/${eessi_repo}/versions
+
+# determine job output file
+job_out_file=slurm-${SLURM_JOB_ID}.out
+job_result_file=_bot_job${SLURM_JOB_ID}.result
+# TODO adjust format to what NESSI bot uses
+if [[ ! -e ${job_out_file} ]]; then
+    echo "[RESULT]" > ${job_result_file}
+    echo "summary = :shrug: UNKNOWN" >> ${job_result_file}
+    echo "details = _job output file '${job_out_file}' not found/not accessible_" >> ${job_result_file}
+    exit 0
+fi
+
+# status of build job (SUCCESS/FAILURE) + details
+# SUCCESS (all of)
+# - last line with failed=0
+# - tarball
+# FAILED (one of)
+# - no last line with failed=0
+# - no tarball
+
+play_recap=0
+PLAY_RECAP=$(grep -A1 "PLAY RECAP" ${job_out_file})
+ec=$?
+echo "PLAY_RECAP.ec=${ec}"
+[[ ${ec} -eq 0 ]] && play_recap=0 || play_recap=1
+echo "play_recap=${play_recap}"
+
+found_line_with_failed=0
+echo "${PLAY_RECAP}" | grep "failed=" > /dev/null
+ec=$?
+echo "FAILED=.ec=${ec}"
+[[ ${ec} -eq 0 ]] && found_line_with_failed=0 || found_line_with_failed=1
+echo "found_line_with_failed=${found_line_with_failed}"
+
+failed_eq_zero=0
+echo "${PLAY_RECAP}" | grep "failed=0" > /dev/null
+ec=$?
+echo "FAILED=0.ec=${ec}"
+[[ ${ec} -eq 0 ]] && failed_eq_zero=0 || failed_eq_zero=1
+echo "failed_eq_zero=${failed_eq_zero}"
+
+found_tarballs=0
+tarballs=$(ls eessi-${eessi_version}-compat-linux-${eessi_arch}-*.tar.gz 2>&1)
+ec=$?
+echo "TARBALLS.ec=${ec}"
+if [[ ${ec} -eq 0 ]]; then
+    found_tarballs=0
+else
+    found_tarballs=1
+fi
+echo "found_tarballs=${found_tarballs}"
+
+# TODO adjust format to what NESSI bot uses
+if [[ ${failed_eq_zero} -eq 0 ]] && [[ ${found_tarballs} -eq 0 ]]; then
+    # SUCCESS
+    echo "[RESULT]" > ${job_result_file}
+    echo "summary = :grin: SUCCESS" >> ${job_result_file}
+    echo "details =" >> ${job_result_file}
+    echo "    no task failed" >> ${job_result_file}
+    echo "    found tarball(s)" >> ${job_result_file}
+    echo "artefacts =" >> ${job_result_file}
+    echo "${tarballs}" | sed -e 's/^/    /' >> ${job_result_file}
+    exit 0
+else
+    # FAILURE
+    echo "[RESULT]" > ${job_result_file}
+    echo "summary = :cry: FAILURE" >> ${job_result_file}
+    echo "details =" >> ${job_result_file}
+    if [[ ${failed_eq_zero} -eq 0 ]]; then
+        echo "    no task failed" >> ${job_result_file}
+    else
+        echo "    some task(s) failed" >> ${job_result_file}
+    fi
+    if [[ ${found_tarballs} -eq 0 ]]; then
+        echo "    found tarball(s)" >> ${job_result_file}
+    else
+        echo "    no tarball found" >> ${job_result_file}
+    fi
+    echo "artefacts =" >> ${job_result_file}
+    if [[ ${found_tarballs} -eq 0 ]]; then
+        echo "${tarballs}" | sed -e 's/^/    /' >> ${job_result_file}
+    fi
+    exit 0
+fi

--- a/bot/check-result.sh
+++ b/bot/check-result.sh
@@ -103,9 +103,9 @@ host_arch=$(uname -m)
 eessi_arch=${cpu_target_arch:-${host_arch}}
 eessi_os=linux
 job_version=$(cfg_get_value "repository" "repo_version")
-eessi_version=${job_version:-2023.06}
+eessi_version=${job_version:-2023.09}
 job_repo=$(cfg_get_value "repository" "repo_name")
-eessi_repo=${job_repo:-pilot.eessi-hpc.org}
+eessi_repo=${job_repo:-software.eessi.io}
 tar_topdir=/cvmfs/${eessi_repo}/versions
 
 # determine job output file

--- a/bot/check-result.sh
+++ b/bot/check-result.sh
@@ -32,49 +32,49 @@
 #### TASK [compatibility_layer : Create Gentoo prefix path and log directory] *******
 #### changed: [localhost] => (item=/cvmfs/pilot.eessi-hpc.org/versions/2023.04/compat/linux/x86_64)
 #### changed: [localhost] => (item=/tmp/eessi-logs)
-#### 
+####
 #### TASK [compatibility_layer : Add custom overlay configuration] ******************
-#### skipping: [localhost] => (item={'name': 'eessi', 'source': 'git', 'url': 'https://github.com/trz42/gentoo-overlay.git', 'eclass-overrides': True}) 
+#### skipping: [localhost] => (item={'name': 'eessi', 'source': 'git', 'url': 'https://github.com/trz42/gentoo-overlay.git', 'eclass-overrides': True})
 #### skipping: [localhost]
-#### 
+####
 #### TASK [compatibility_layer : Make configuration file with overlays that can override eclasses] ***
 #### ok: [localhost]
-#### 
+####
 #### TASK [compatibility_layer : Sync the repositories] *****************************
 #### ok: [localhost]
-#### 
+####
 #### TASK [compatibility_layer : Run Gentoo Prefix bootstrap stages 1-3 via /tmp/bootstrap-prefix.sh /cvmfs/pilot.eessi-hpc.org/versions/2023.04/compat/linux/x86_64 noninteractive] ***
 #### changed: [localhost]
-#### 
+####
 #### TASK [compatibility_layer : Specify use flags before completing bootstrap] *****
 #### changed: [localhost]
-#### 
+####
 #### TASK [compatibility_layer : Continue Gentoo Prefix bootstrap via /tmp/bootstrap-prefix.sh /cvmfs/pilot.eessi-hpc.org/versions/2023.04/compat/linux/x86_64 noninteractive] ***
 #### changed: [localhost]
-#### 
+####
 #### TASK [compatibility_layer : (Re)install glibc with the user-defined-trusted-dirs option] ***
 #### skipping: [localhost]
-#### 
+####
 #### TASK [compatibility_layer : Create portage env directory] **********************
 #### ok: [localhost]
-#### 
+####
 #### TASK [compatibility_layer : Add env file for glibc to make sure the user-defined-trusted-dirs is always used] ***
 #### ok: [localhost]
-#### 
+####
 #### TASK [compatibility_layer : Install package set ['eessi-2023.04-linux-x86_64']] ***
 #### ok: [localhost] => (item=eessi-2023.04-linux-x86_64)
-#### 
+####
 #### TASK [compatibility_layer : Remove redundant packages] *************************
 #### ok: [localhost] => (item=dev-lang/go)
 #### ok: [localhost] => (item=dev-lang/go-bootstrap)
-#### 
+####
 #### TASK [compatibility_layer : Run ReFrame tests] *********************************
 #### ok: [localhost]
 
 # end of job output
 #### PLAY RECAP *********************************************************************
-#### localhost                  : ok=17   changed=13   unreachable=0    failed=1    skipped=6    rescued=0    ignored=0   
-#### localhost                  : ok=38   changed=3    unreachable=0    failed=0    skipped=5    rescued=0    ignored=1   
+#### localhost                  : ok=17   changed=13   unreachable=0    failed=1    skipped=6    rescued=0    ignored=0
+#### localhost                  : ok=38   changed=3    unreachable=0    failed=0    skipped=5    rescued=0    ignored=1
 
 
 # stop as soon as something fails

--- a/install_compatibility_layer.sh
+++ b/install_compatibility_layer.sh
@@ -6,11 +6,11 @@
 
 ARCH=
 CONTAINER=docker://ghcr.io/eessi/bootstrap-prefix:debian11
-REPOSITORY="pilot.eessi-hpc.org"
+REPOSITORY="software.nessi.no"
 RESUME=
 RETAIN_TMP=0
 STORAGE=
-VERSION=2023.06
+VERSION=2023.09
 VERBOSE=
 
 display_help() {

--- a/test/compat_layer.py
+++ b/test/compat_layer.py
@@ -4,7 +4,7 @@ import reframe as rfm
 import reframe.utility.sanity as sn
 
 
-EESSI_REPO_DIR = '/cvmfs/pilot.nessi.no'
+EESSI_REPO_DIR = '/cvmfs/software.nessi.no'
 
 class RunInGentooPrefixTestError(rfm.core.exceptions.ReframeError):
     pass

--- a/test/compat_layer.py
+++ b/test/compat_layer.py
@@ -4,7 +4,7 @@ import reframe as rfm
 import reframe.utility.sanity as sn
 
 
-EESSI_REPO_DIR = '/cvmfs/pilot.eessi-hpc.org'
+EESSI_REPO_DIR = '/cvmfs/pilot.nessi.no'
 
 class RunInGentooPrefixTestError(rfm.core.exceptions.ReframeError):
     pass


### PR DESCRIPTION
First attempt to create a new compat layer by only changing the prefix and the version
* `pilot.nessi.no` $\Longrightarrow$ `software.nessi.no`
* `2023.06` $\Longrightarrow$ `2023.09`

No other changes were included. That is neither the main script `bootstrap-prefix.sh` nor the Gentoo commit (still `aab8473aa90e0287553b3348a5c5b17872df4b7b` from June 8, 2023) nor any other settings or packages to be installed via the EESSI overlay were changed.