### PR TITLE
Update compat layer NESSI/2023.06

### DIFF
--- a/scripts/update-pkgs-NESSI-2023.06-2024-02-22.sh
+++ b/scripts/update-pkgs-NESSI-2023.06-2024-02-22.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+
+set -e
+
+mytmpdir=$(mktemp -d --tmpdir=/tmp)
+
+if [ -z "$EPREFIX" ]; then
+    # this assumes we're running in a Gentoo Prefix environment
+    EPREFIX=$(dirname $(dirname $SHELL))
+fi
+echo "EPREFIX=${EPREFIX}"
+
+# collect list of installed packages before updating packages
+list_installed_pkgs_pre_update=${mytmpdir}/installed-pkgs-pre-update.txt
+echo "Collecting list of installed packages to ${list_installed_pkgs_pre_update}..."
+qlist -IRv | sort | tee ${list_installed_pkgs_pre_update}
+
+# update checkout of gentoo repository to an even more recent commit,
+# which contains the required versions of openssl and glibc
+# https://gitweb.gentoo.org/repo/gentoo.git/commit/?id=ac78a6d2a0ec2546a59ed98e00499ddd8343b13d (2024-01-31)
+gentoo_commit='ac78a6d2a0ec2546a59ed98e00499ddd8343b13d'
+echo "Updating $EPREFIX/var/db/repos/gentoo to recent commit (${gentoo_commit})..."
+cd $EPREFIX/var/db/repos/gentoo
+time git fetch origin
+echo "Checking out ${gentoo_commit} in ${PWD}..."
+time git checkout ${gentoo_commit}
+cd -
+
+# unmask dev-libs/openssl-1.1.1w, so we can update to it
+# (masked by $EPREFIX/var/db/repos/gentoo/profiles/package.mask, because OpenSSL 1.1.x is EOL)
+echo '# unmask dev-libs/openssl-1.1.1w (openssl 1.1.x is masked via $EPREFIX/var/db/repos/gentoo/profiles/package.mask)' >> ${EPREFIX}/etc/portage/package.unmask
+echo '=dev-libs/openssl-1.1.1w' >> ${EPREFIX}/etc/portage/package.unmask
+# update openssl due to https://nvd.nist.gov/vuln/detail/CVE-2023-4807
+emerge --update --oneshot --verbose '=dev-libs/openssl-1.1.1w'  # was dev-libs/openssl-1.1.1u
+
+# update glibc due to https://security.gentoo.org/glsa/202402-01
+emerge --update --oneshot --verbose '=sys-libs/glibc-2.37-r10'  # was sys-libs/glibc-2.37-r7
+
+# collect list of installed packages after updating packages
+list_installed_pkgs_post_update=${mytmpdir}/installed-pkgs-post-update.txt
+echo "Collecting list of installed packages to ${list_installed_pkgs_post_update}..."
+qlist -IRv | sort | tee ${list_installed_pkgs_post_update}
+
+echo
+echo "diff in installed packages:"
+diff -u ${list_installed_pkgs_pre_update} ${list_installed_pkgs_post_update}
+
+rm -rf ${mytmpdir}


### PR DESCRIPTION
Updates buggy glibc2.37-r7 --> glibc-2.37-r10 and openssl-1.1.1u --> openssl-1.1.1w as a step of getting closer to EESSI

<details><summary>diff for x86_64</summary>

  ```
 --- /tmp/tmp.lOFVc05MrY/installed-pkgs-pre-update.txt   2024-02-23 07:59:47.625111297 +0000
+++ /tmp/tmp.lOFVc05MrY/installed-pkgs-post-update.txt  2024-02-23 09:10:33.525396274 +0000
@@ -112,7 +112,7 @@
 dev-libs/mpfr-4.2.0_p9::gentoo
 dev-libs/nettle-3.9.1::gentoo
 dev-libs/npth-1.6-r1::gentoo
-dev-libs/openssl-1.1.1u::gentoo
+dev-libs/openssl-1.1.1w::gentoo
 dev-libs/popt-1.19::gentoo
 dev-lua/lpeg-1.0.2-r101::gentoo
 dev-lua/lua-bit32-5.3.5.1-r1::gentoo
@@ -295,7 +295,7 @@
 sys-kernel/installkernel-7::gentoo
 sys-kernel/linux-headers-6.3::gentoo
 sys-libs/gdbm-1.23::gentoo
-sys-libs/glibc-2.37-r7::gentoo
+sys-libs/glibc-2.37-r10::gentoo
 sys-libs/libcap-2.69::gentoo
 sys-libs/libseccomp-2.5.4::gentoo
 sys-libs/libxcrypt-4.4.35::gentoo
  ```
</details>
<details><summary>qlist for x86_64</summary>

```
acct-group/audio-0-r1::gentoo
acct-group/cdrom-0-r1::gentoo
acct-group/dialout-0-r1::gentoo
acct-group/disk-0-r1::gentoo
acct-group/floppy-0::gentoo
acct-group/input-0-r1::gentoo
acct-group/kmem-0-r1::gentoo
acct-group/kvm-0-r1::gentoo
acct-group/lp-0-r1::gentoo
acct-group/man-0-r1::gentoo
acct-group/messagebus-0-r1::gentoo
acct-group/portage-0::gentoo
acct-group/render-0-r1::gentoo
acct-group/root-0::gentoo
acct-group/sgx-0::gentoo
acct-group/tape-0-r1::gentoo
acct-group/tty-0-r1::gentoo
acct-group/usb-0-r1::gentoo
acct-group/video-0-r1::gentoo
acct-user/man-1-r1::gentoo
acct-user/messagebus-0-r1::gentoo
acct-user/portage-0::gentoo
app-admin/eselect-1.4.24::gentoo
app-admin/perl-cleaner-2.30-r1::gentoo
app-alternatives/awk-4::gentoo
app-alternatives/bc-0::gentoo
app-alternatives/bzip2-1::gentoo
app-alternatives/gzip-0::gentoo
app-alternatives/lex-0-r1::gentoo
app-alternatives/sh-0::gentoo
app-alternatives/tar-0::gentoo
app-alternatives/yacc-1-r2::gentoo
app-arch/bzip2-1.0.8-r4::gentoo
app-arch/gzip-1.12-r4::gentoo
app-arch/libarchive-3.7.2::gentoo
app-arch/tar-1.34-r3::gentoo
app-arch/unzip-6.0_p27-r1::gentoo
app-arch/xz-utils-5.4.3::gentoo
app-arch/zstd-1.5.5::gentoo
app-crypt/gnupg-2.4.2::gentoo
app-crypt/gpgme-1.20.0::gentoo
app-crypt/libb2-0.98.1-r3::gentoo
app-crypt/pinentry-1.2.1-r3::gentoo
app-crypt/rhash-1.4.3::gentoo
app-editors/nano-7.2::gentoo
app-eselect/eselect-fontconfig-20220403::gentoo
app-eselect/eselect-lib-bin-symlink-0.1.1-r1::gentoo
app-eselect/eselect-lua-4-r1::gentoo
app-eselect/eselect-pinentry-0.7.2-r1::gentoo
app-eselect/eselect-repository-13::gentoo
app-misc/ca-certificates-20230311.3.90::gentoo
app-misc/editor-wrapper-4-r1::gentoo
app-misc/mime-types-2.1.54::gentoo
app-misc/pax-utils-1.3.7::gentoo
app-portage/elt-patches-20221210::gentoo
app-portage/gentoolkit-0.6.1-r3::gentoo
app-portage/portage-utils-0.96::gentoo
app-portage/prefix-toolkit-10-r1::gentoo
app-shells/bash-5.2_p15-r3::gentoo
app-shells/bash-completion-2.11::gentoo
app-shells/gentoo-bashcomp-20230313::gentoo
app-shells/tcsh-6.24.01-r1::gentoo
app-text/build-docbook-catalog-2.4::gentoo
app-text/docbook-xml-dtd-4.5-r2::gentoo
app-text/docbook-xml-dtd-4.4-r3::gentoo
app-text/docbook-xml-dtd-4.2-r3::gentoo
app-text/docbook-xml-dtd-4.1.2-r7::gentoo
app-text/docbook-xsl-stylesheets-1.79.1-r4::gentoo
app-text/manpager-1::gentoo
app-text/opensp-1.5.2-r10::gentoo
app-text/po4a-0.69::gentoo
app-text/sgml-common-0.6.3-r7::gentoo
app-text/xmlto-0.0.28-r10::gentoo
dev-build/autoconf-2.71-r6::gentoo
dev-build/autoconf-archive-2023.02.20::gentoo
dev-build/autoconf-wrapper-20221207-r1::gentoo
dev-build/automake-1.16.5-r1::gentoo
dev-build/automake-wrapper-20221207::gentoo
dev-build/gtk-doc-am-1.33.2::gentoo
dev-build/libtool-2.4.7-r1::gentoo
dev-build/make-4.4.1-r1::gentoo
dev-build/meson-1.1.1::gentoo
dev-build/meson-format-array-0::gentoo
dev-db/sqlite-3.42.0::gentoo
dev-lang/lua-5.1.5-r200::gentoo
dev-lang/luajit-2.1.0_beta3_p20220613::gentoo
dev-lang/perl-5.36.1-r2::gentoo
dev-lang/python-3.12.0_beta2::gentoo
dev-lang/python-3.11.4::gentoo
dev-lang/python-exec-2.4.10::gentoo
dev-lang/python-exec-conf-2.4.6::gentoo
dev-lang/tcl-8.6.13-r1::gentoo
dev-lang/tk-8.6.13::gentoo
dev-libs/expat-2.5.0::gentoo
dev-libs/gmp-6.2.1-r5::gentoo
dev-libs/jsoncpp-1.9.5::gentoo
dev-libs/libassuan-2.5.5::gentoo
dev-libs/libffi-3.4.4-r1::gentoo
dev-libs/libgcrypt-1.10.2::gentoo
dev-libs/libgpg-error-1.47::gentoo
dev-libs/libksba-1.6.3::gentoo
dev-libs/libltdl-2.4.7-r1::gentoo
dev-libs/libpcre2-10.42-r1::gentoo
dev-libs/libpipeline-1.5.7::gentoo
dev-libs/libtasn1-4.19.0::gentoo
dev-libs/libunistring-1.1-r1::gentoo
dev-libs/libuv-1.45.0::gentoo
dev-libs/libxml2-2.11.4::gentoo
dev-libs/libxslt-1.1.38::gentoo
dev-libs/libyaml-0.2.5::gentoo
dev-libs/mpc-1.3.1::gentoo
dev-libs/mpfr-4.2.0_p9::gentoo
dev-libs/nettle-3.9.1::gentoo
dev-libs/npth-1.6-r1::gentoo
dev-libs/openssl-1.1.1u::gentoo
dev-libs/popt-1.19::gentoo
dev-lua/lpeg-1.0.2-r101::gentoo
dev-lua/lua-bit32-5.3.5.1-r1::gentoo
dev-lua/lua-term-0.7-r2::gentoo
dev-lua/luafilesystem-1.8.0-r101::gentoo
dev-lua/luajson-1.3.4::gentoo
dev-lua/luaposix-36.1::gentoo
dev-perl/Authen-SASL-2.160.0-r2::gentoo
dev-perl/Digest-HMAC-1.40.0::gentoo
dev-perl/Error-0.170.290::gentoo
dev-perl/ExtUtils-CChecker-0.110.0::gentoo
dev-perl/IO-Socket-SSL-2.83.0::gentoo
dev-perl/Locale-gettext-1.70.0-r1::gentoo
dev-perl/MailTools-2.210.0::gentoo
dev-perl/MIME-Charset-1.13.1::gentoo
dev-perl/Module-Build-0.423.100::gentoo
dev-perl/Mozilla-CA-20999999-r1::gentoo
dev-perl/Net-SSLeay-1.920.0-r1::gentoo
dev-perl/Pod-Parser-1.630.0-r1::gentoo
dev-perl/SGMLSpm-1.1-r2::gentoo
dev-perl/Syntax-Keyword-Try-0.270.0::gentoo
dev-perl/TermReadKey-2.380.0-r1::gentoo
dev-perl/Text-CharWidth-0.40.0-r2::gentoo
dev-perl/Text-WrapI18N-0.60.0-r2::gentoo
dev-perl/TimeDate-2.330.0-r1::gentoo
dev-perl/Unicode-LineBreak-2019.1.0::gentoo
dev-perl/XS-Parse-Keyword-0.330.0::gentoo
dev-perl/YAML-Tiny-1.730.0-r1::gentoo
dev-python/arrow-1.2.3::gentoo
dev-python/attrs-23.1.0::gentoo
dev-python/autocommand-2.2.2::gentoo
dev-python/calver-2022.06.26::gentoo
dev-python/certifi-3021.3.16-r3::gentoo
dev-python/cffi-1.15.1-r3::gentoo
dev-python/colorama-0.4.6::gentoo
dev-python/cryptography-41.0.1::gentoo
dev-python/cython-0.29.35::gentoo
dev-python/editables-0.3::gentoo
dev-python/ensurepip-pip-23.1.2::gentoo
dev-python/ensurepip-setuptools-67.8.0::gentoo
dev-python/ensurepip-wheels-100::gentoo
dev-python/flit-core-3.9.0::gentoo
dev-python/fqdn-1.5.1-r2::gentoo
dev-python/gentoo-common-1::gentoo
dev-python/gitdb-4.0.10::gentoo
dev-python/GitPython-3.1.31::gentoo
dev-python/gpep517-13::gentoo
dev-python/hatch-fancy-pypi-readme-23.1.0::gentoo
dev-python/hatch-vcs-0.3.0::gentoo
dev-python/hatchling-1.17.1::gentoo
dev-python/idna-3.4::gentoo
dev-python/importlib-metadata-6.6.0::gentoo
dev-python/inflect-6.0.4::gentoo
dev-python/iniconfig-2.0.0::gentoo
dev-python/installer-0.7.0::gentoo
dev-python/isoduration-20.11.0-r1::gentoo
dev-python/jaraco-classes-3.2.3::gentoo
dev-python/jaraco-context-4.3.0::gentoo
dev-python/jaraco-functools-3.7.0::gentoo
dev-python/jaraco-text-3.11.1::gentoo
dev-python/jeepney-0.8.0::gentoo
dev-python/jinja-3.1.2::gentoo
dev-python/jsonpointer-2.3::gentoo
dev-python/jsonschema-4.17.3::gentoo
dev-python/keyring-23.13.1-r1::gentoo
dev-python/lark-1.1.5::gentoo
dev-python/linkify-it-py-2.0.2::gentoo
dev-python/lxml-4.9.2-r1::gentoo
dev-python/markdown-it-py-3.0.0::gentoo
dev-python/markupsafe-2.1.3::gentoo
dev-python/mdurl-0.1.2::gentoo
dev-python/more-itertools-9.1.0::gentoo
dev-python/nspektr-0.4.0::gentoo
dev-python/ordered-set-4.1.0::gentoo
dev-python/packaging-23.1::gentoo
dev-python/pathspec-0.11.1::gentoo
dev-python/pip-23.1.2::gentoo
dev-python/platformdirs-3.5.1::gentoo
dev-python/pluggy-1.0.0-r2::gentoo
dev-python/ply-3.11-r2::gentoo
dev-python/poetry-core-1.6.1::gentoo
dev-python/pycodestyle-2.10.0::gentoo
dev-python/pycparser-2.21-r2::gentoo
dev-python/pydantic-1.10.9::gentoo
dev-python/pygments-2.15.1::gentoo
dev-python/pyparsing-3.0.9::gentoo
dev-python/pyrsistent-0.19.3::gentoo
dev-python/pytest-7.3.1-r2::gentoo
dev-python/python-dateutil-2.8.2-r1::gentoo
dev-python/pyyaml-6.0-r1::gentoo
dev-python/regex-2023.6.3::gentoo
dev-python/rfc3339-validator-0.1.4-r1::gentoo
dev-python/rfc3986-validator-0.1.1-r1::gentoo
dev-python/rfc3987-1.3.8-r2::gentoo
dev-python/rich-13.4.1::gentoo
dev-python/secretstorage-3.3.3::gentoo
dev-python/semantic-version-2.10.0::gentoo
dev-python/setuptools-67.8.0::gentoo
dev-python/setuptools-scm-7.1.0::gentoo
dev-python/six-1.16.0-r1::gentoo
dev-python/smmap-5.0.0-r1::gentoo
dev-python/strict-rfc3339-0.7-r2::gentoo
dev-python/tomli-2.0.1-r1::gentoo
dev-python/trove-classifiers-2023.5.24::gentoo
dev-python/typing-extensions-4.6.3::gentoo
dev-python/uc-micro-py-1.0.2::gentoo
dev-python/uri-template-1.2.0-r1::gentoo
dev-python/webcolors-1.13::gentoo
dev-python/wheel-0.40.0::gentoo
dev-python/zipp-3.15.0::gentoo
dev-util/direnv-2.32.2::eessi
dev-util/gperf-3.1-r1::gentoo
dev-util/hermes-2.9::gentoo
dev-util/patchelf-0.18.0::gentoo
dev-util/pkgconf-1.8.1::gentoo
dev-util/re2c-2.2::gentoo
dev-vcs/git-2.41.0::gentoo
media-fonts/dejavu-2.37::gentoo
media-fonts/liberation-fonts-2.1.5::gentoo
media-libs/fontconfig-2.14.2-r3::gentoo
media-libs/freetype-2.13.0::gentoo
media-libs/libpng-1.6.39::gentoo
net-dns/c-ares-1.19.1::gentoo
net-dns/libidn2-2.3.4::gentoo
net-libs/gnutls-3.8.0::gentoo
net-libs/libnsl-2.0.0-r1::gentoo
net-libs/libtirpc-1.3.3::gentoo
net-libs/nghttp2-1.52.0::gentoo
net-misc/curl-8.4.0::gentoo
net-misc/rsync-3.2.7-r2::gentoo
net-misc/wget-1.21.4::gentoo
perl-core/File-Temp-0.231.100::gentoo
sys-apps/acl-2.3.1-r2::gentoo
sys-apps/archspec-0.2.1::eessi
sys-apps/attr-2.5.1-r2::gentoo
sys-apps/baselayout-2.13-r1::gentoo
sys-apps/coreutils-9.3-r1::gentoo
sys-apps/dbus-1.15.6::gentoo
sys-apps/debianutils-5.7::gentoo
sys-apps/diffutils-3.10::gentoo
sys-apps/file-5.44-r3::gentoo
sys-apps/findutils-4.9.0-r2::gentoo
sys-apps/gawk-5.2.2::gentoo
sys-apps/gentoo-functions-0.19::gentoo
sys-apps/grep-3.11::gentoo
sys-apps/groff-1.22.4::gentoo
sys-apps/help2man-1.49.3::gentoo
sys-apps/kmod-30-r1::gentoo
sys-apps/less-633::gentoo
sys-apps/locale-gen-2.23-r1::gentoo
sys-apps/lsb-release-3.2::gentoo
sys-apps/man-db-2.11.2::gentoo
sys-apps/miscfiles-1.5-r4::gentoo
sys-apps/net-tools-2.10::gentoo
sys-apps/portage-3.0.48.1::gentoo
sys-apps/sandbox-2.30-r1::gentoo
sys-apps/sed-4.9::gentoo
sys-apps/systemd-utils-253.5::gentoo
sys-apps/texinfo-7.0.3::gentoo
sys-apps/util-linux-2.38.1-r2::gentoo
sys-apps/which-2.21::gentoo
sys-auth/pambase-20220214::gentoo
sys-auth/passwdqc-2.0.2-r1::gentoo
sys-cluster/lmod-8.7.23::gentoo
sys-cluster/rdma-core-45.0::gentoo
sys-devel/bc-1.07.1-r6::gentoo
sys-devel/binutils-2.40-r5::gentoo
sys-devel/binutils-config-5.5::gentoo
sys-devel/bison-3.8.2-r2::gentoo
sys-devel/flex-2.6.4-r6::gentoo
sys-devel/gcc-10.4.1_p20230517::gentoo
sys-devel/gcc-config-2.11::gentoo
sys-devel/gettext-0.21.1::gentoo
sys-devel/gnuconfig-20230121::gentoo
sys-devel/m4-1.4.19-r2::gentoo
sys-devel/patch-2.7.6-r5::gentoo
sys-fabric/opa-psm2-11.2.205::eessi
sys-fs/e2fsprogs-1.47.0-r1::gentoo
sys-fs/udev-init-scripts-35::gentoo
sys-kernel/installkernel-7::gentoo
sys-kernel/linux-headers-6.3::gentoo
sys-libs/gdbm-1.23::gentoo
sys-libs/glibc-2.37-r7::gentoo
sys-libs/libcap-2.69::gentoo
sys-libs/libseccomp-2.5.4::gentoo
sys-libs/libxcrypt-4.4.35::gentoo
sys-libs/ncurses-6.4_p20230401::gentoo
sys-libs/pam-1.5.3::gentoo
sys-libs/readline-8.2_p1::gentoo
sys-libs/timezone-data-2023c::gentoo
sys-libs/zlib-1.3-r2::gentoo
sys-process/numactl-2.0.16::gentoo
sys-process/procps-3.3.17-r1::gentoo
sys-process/psmisc-23.6::gentoo
virtual/acl-0-r2::gentoo
virtual/editor-0-r5::gentoo
virtual/libc-1-r1::gentoo
virtual/libcrypt-2-r1::gentoo
virtual/libiconv-0-r2::gentoo
virtual/libintl-0-r2::gentoo
virtual/libudev-232-r7::gentoo
virtual/man-0-r4::gentoo
virtual/os-headers-0-r2::gentoo
virtual/package-manager-1::gentoo
virtual/pager-0-r1::gentoo
virtual/perl-Carp-1.520.0-r2::gentoo
virtual/perl-CPAN-2.330.0::gentoo
virtual/perl-CPAN-Meta-2.150.10-r7::gentoo
virtual/perl-CPAN-Meta-YAML-0.18.0-r9::gentoo
virtual/perl-Data-Dumper-2.184.0::gentoo
virtual/perl-Digest-MD5-2.580.0-r1::gentoo
virtual/perl-Digest-SHA-6.20.0-r3::gentoo
virtual/perl-Encode-3.170.0::gentoo
virtual/perl-Exporter-5.770.0-r1::gentoo
virtual/perl-ExtUtils-CBuilder-0.280.236-r1::gentoo
virtual/perl-ExtUtils-Install-2.200.0-r1::gentoo
virtual/perl-ExtUtils-MakeMaker-7.640.0::gentoo
virtual/perl-ExtUtils-Manifest-1.730.0-r2::gentoo
virtual/perl-ExtUtils-ParseXS-3.450.0::gentoo
virtual/perl-File-Spec-3.840.0::gentoo
virtual/perl-File-Temp-0.231.100::gentoo
virtual/perl-Getopt-Long-2.520.0-r1::gentoo
virtual/perl-IO-1.500.0::gentoo
virtual/perl-JSON-PP-4.70.0::gentoo
virtual/perl-libnet-3.140.0::gentoo
virtual/perl-MIME-Base64-3.160.0-r1::gentoo
virtual/perl-Module-Metadata-1.0.37-r3::gentoo
virtual/perl-Parse-CPAN-Meta-2.150.10-r7::gentoo
virtual/perl-Perl-OSType-1.10.0-r7::gentoo
virtual/perl-podlators-4.140.0-r3::gentoo
virtual/perl-Scalar-List-Utils-1.620.0::gentoo
virtual/perl-Test-Harness-3.440.0-r1::gentoo
virtual/perl-Text-ParseWords-3.310.0-r1::gentoo
virtual/perl-version-0.992.900-r1::gentoo
virtual/pkgconfig-2-r1::gentoo
virtual/tmpfiles-0-r3::gentoo
virtual/ttf-fonts-1-r2::gentoo
virtual/udev-217-r5::gentoo
x11-base/xcb-proto-1.15.2::gentoo
x11-base/xorg-proto-2023.1::gentoo
x11-libs/libICE-1.1.1-r1::gentoo
x11-libs/libSM-1.2.4::gentoo
x11-libs/libX11-1.8.5::gentoo
x11-libs/libXau-1.0.11::gentoo
x11-libs/libxcb-1.15-r1::gentoo
x11-libs/libXdmcp-1.1.4-r2::gentoo
x11-libs/libXt-1.3.0::gentoo
x11-libs/xtrans-1.5.0::gentoo
x11-misc/compose-tables-1.8.5::gentoo

```
</details>

<details><summary>diff for aarch64</summary>

  ```
  --- list_installed_pkgs_pre_update	2024-02-23 13:54:30.406337200 +0100
+++ list_installed_pkgs_post_update	2024-02-23 13:54:45.241620226 +0100
@@ -71,6 +71,16 @@
 app-text/po4a-0.69::gentoo
 app-text/sgml-common-0.6.3-r7::gentoo
 app-text/xmlto-0.0.28-r10::gentoo
+dev-build/autoconf-2.71-r6::gentoo
+dev-build/autoconf-archive-2023.02.20::gentoo
+dev-build/autoconf-wrapper-20221207-r1::gentoo
+dev-build/automake-1.16.5-r1::gentoo
+dev-build/automake-wrapper-20221207::gentoo
+dev-build/gtk-doc-am-1.33.2::gentoo
+dev-build/libtool-2.4.7-r1::gentoo
+dev-build/make-4.4.1-r1::gentoo
+dev-build/meson-1.1.1::gentoo
+dev-build/meson-format-array-0::gentoo
 dev-db/sqlite-3.42.0::gentoo
 dev-lang/lua-5.1.5-r200::gentoo
 dev-lang/luajit-2.1.0_beta3_p20220613::gentoo
@@ -102,7 +112,7 @@
 dev-libs/mpfr-4.2.0_p9::gentoo
 dev-libs/nettle-3.9.1::gentoo
 dev-libs/npth-1.6-r1::gentoo
-dev-libs/openssl-1.1.1u::gentoo
+dev-libs/openssl-1.1.1w::gentoo
 dev-libs/popt-1.19::gentoo
 dev-lua/lpeg-1.0.2-r101::gentoo
 dev-lua/lua-bit32-5.3.5.1-r1::gentoo
@@ -209,16 +219,13 @@
 dev-python/trove-classifiers-2023.5.24::gentoo
 dev-python/typing-extensions-4.6.3::gentoo
 dev-python/uc-micro-py-1.0.2::gentoo
-dev-python/uri_template-1.2.0-r1::gentoo
+dev-python/uri-template-1.2.0-r1::gentoo
 dev-python/webcolors-1.13::gentoo
 dev-python/wheel-0.40.0::gentoo
 dev-python/zipp-3.15.0::gentoo
 dev-util/direnv-2.32.2::eessi
 dev-util/gperf-3.1-r1::gentoo
-dev-util/gtk-doc-am-1.33.2::gentoo
 dev-util/hermes-2.9::gentoo
-dev-util/meson-1.1.1::gentoo
-dev-util/meson-format-array-0::gentoo
 dev-util/patchelf-0.18.0::gentoo
 dev-util/pkgconf-1.8.1::gentoo
 dev-util/re2c-2.2::gentoo
@@ -271,11 +278,6 @@
 sys-auth/passwdqc-2.0.2-r1::gentoo
 sys-cluster/lmod-8.7.23::gentoo
 sys-cluster/rdma-core-45.0::gentoo
-sys-devel/autoconf-2.71-r6::gentoo
-sys-devel/autoconf-archive-2023.02.20::gentoo
-sys-devel/autoconf-wrapper-20221207-r1::gentoo
-sys-devel/automake-1.16.5-r1::gentoo
-sys-devel/automake-wrapper-20221207::gentoo
 sys-devel/bc-1.07.1-r6::gentoo
 sys-devel/binutils-2.40-r5::gentoo
 sys-devel/binutils-config-5.5::gentoo
@@ -285,16 +287,14 @@
 sys-devel/gcc-config-2.11::gentoo
 sys-devel/gettext-0.21.1::gentoo
 sys-devel/gnuconfig-20230121::gentoo
-sys-devel/libtool-2.4.7-r1::gentoo
 sys-devel/m4-1.4.19-r2::gentoo
-sys-devel/make-4.4.1-r1::gentoo
 sys-devel/patch-2.7.6-r5::gentoo
 sys-fs/e2fsprogs-1.47.0-r1::gentoo
 sys-fs/udev-init-scripts-35::gentoo
-sys-kernel/installkernel-gentoo-7::gentoo
+sys-kernel/installkernel-7::gentoo
 sys-kernel/linux-headers-6.3::gentoo
 sys-libs/gdbm-1.23::gentoo
-sys-libs/glibc-2.37-r3::gentoo
+sys-libs/glibc-2.37-r10::gentoo
 sys-libs/libcap-2.69::gentoo
 sys-libs/libseccomp-2.5.4::gentoo
 sys-libs/libxcrypt-4.4.35::gentoo
  ```
</details>

</details>
<details><summary>qlist for aarch64</summary>

```
acct-group/audio-0-r1::gentoo
acct-group/cdrom-0-r1::gentoo
acct-group/dialout-0-r1::gentoo
acct-group/disk-0-r1::gentoo
acct-group/floppy-0::gentoo
acct-group/input-0-r1::gentoo
acct-group/kmem-0-r1::gentoo
acct-group/kvm-0-r1::gentoo
acct-group/lp-0-r1::gentoo
acct-group/man-0-r1::gentoo
acct-group/messagebus-0-r1::gentoo
acct-group/portage-0::gentoo
acct-group/render-0-r1::gentoo
acct-group/root-0::gentoo
acct-group/sgx-0::gentoo
acct-group/tape-0-r1::gentoo
acct-group/tty-0-r1::gentoo
acct-group/usb-0-r1::gentoo
acct-group/video-0-r1::gentoo
acct-user/man-1-r1::gentoo
acct-user/messagebus-0-r1::gentoo
acct-user/portage-0::gentoo
app-admin/eselect-1.4.24::gentoo
app-admin/perl-cleaner-2.30-r1::gentoo
app-alternatives/awk-4::gentoo
app-alternatives/bc-0::gentoo
app-alternatives/bzip2-1::gentoo
app-alternatives/gzip-0::gentoo
app-alternatives/lex-0-r1::gentoo
app-alternatives/sh-0::gentoo
app-alternatives/tar-0::gentoo
app-alternatives/yacc-1-r2::gentoo
app-arch/bzip2-1.0.8-r4::gentoo
app-arch/gzip-1.12-r4::gentoo
app-arch/libarchive-3.6.2-r1::gentoo
app-arch/tar-1.34-r3::gentoo
app-arch/unzip-6.0_p27-r1::gentoo
app-arch/xz-utils-5.4.3::gentoo
app-arch/zstd-1.5.5::gentoo
app-crypt/gnupg-2.4.2::gentoo
app-crypt/gpgme-1.20.0::gentoo
app-crypt/libb2-0.98.1-r3::gentoo
app-crypt/pinentry-1.2.1-r3::gentoo
app-crypt/rhash-1.4.3::gentoo
app-editors/nano-7.2::gentoo
app-eselect/eselect-fontconfig-20220403::gentoo
app-eselect/eselect-lib-bin-symlink-0.1.1-r1::gentoo
app-eselect/eselect-lua-4-r1::gentoo
app-eselect/eselect-pinentry-0.7.2-r1::gentoo
app-eselect/eselect-repository-13::gentoo
app-misc/ca-certificates-20230311.3.90::gentoo
app-misc/editor-wrapper-4-r1::gentoo
app-misc/mime-types-2.1.54::gentoo
app-misc/pax-utils-1.3.7::gentoo
app-portage/elt-patches-20221210::gentoo
app-portage/gentoolkit-0.6.1-r3::gentoo
app-portage/portage-utils-0.96::gentoo
app-portage/prefix-toolkit-10-r1::gentoo
app-shells/bash-5.2_p15-r3::gentoo
app-shells/bash-completion-2.11::gentoo
app-shells/gentoo-bashcomp-20230313::gentoo
app-shells/tcsh-6.24.01-r1::gentoo
app-text/build-docbook-catalog-2.4::gentoo
app-text/docbook-xml-dtd-4.5-r2::gentoo
app-text/docbook-xml-dtd-4.4-r3::gentoo
app-text/docbook-xml-dtd-4.2-r3::gentoo
app-text/docbook-xml-dtd-4.1.2-r7::gentoo
app-text/docbook-xsl-stylesheets-1.79.1-r4::gentoo
app-text/manpager-1::gentoo
app-text/opensp-1.5.2-r10::gentoo
app-text/po4a-0.69::gentoo
app-text/sgml-common-0.6.3-r7::gentoo
app-text/xmlto-0.0.28-r10::gentoo
dev-build/autoconf-2.71-r6::gentoo
dev-build/autoconf-archive-2023.02.20::gentoo
dev-build/autoconf-wrapper-20221207-r1::gentoo
dev-build/automake-1.16.5-r1::gentoo
dev-build/automake-wrapper-20221207::gentoo
dev-build/gtk-doc-am-1.33.2::gentoo
dev-build/libtool-2.4.7-r1::gentoo
dev-build/make-4.4.1-r1::gentoo
dev-build/meson-1.1.1::gentoo
dev-build/meson-format-array-0::gentoo
dev-db/sqlite-3.42.0::gentoo
dev-lang/lua-5.1.5-r200::gentoo
dev-lang/luajit-2.1.0_beta3_p20220613::gentoo
dev-lang/perl-5.36.1-r2::gentoo
dev-lang/python-3.12.0_beta2::gentoo
dev-lang/python-3.11.4::gentoo
dev-lang/python-exec-2.4.10::gentoo
dev-lang/python-exec-conf-2.4.6::gentoo
dev-lang/tcl-8.6.13-r1::gentoo
dev-lang/tk-8.6.13::gentoo
dev-libs/expat-2.5.0::gentoo
dev-libs/gmp-6.2.1-r5::gentoo
dev-libs/jsoncpp-1.9.5::gentoo
dev-libs/libassuan-2.5.5::gentoo
dev-libs/libffi-3.4.4-r1::gentoo
dev-libs/libgcrypt-1.10.2::gentoo
dev-libs/libgpg-error-1.47::gentoo
dev-libs/libksba-1.6.3::gentoo
dev-libs/libltdl-2.4.7-r1::gentoo
dev-libs/libpcre2-10.42-r1::gentoo
dev-libs/libpipeline-1.5.7::gentoo
dev-libs/libtasn1-4.19.0::gentoo
dev-libs/libunistring-1.1-r1::gentoo
dev-libs/libuv-1.45.0::gentoo
dev-libs/libxml2-2.11.4::gentoo
dev-libs/libxslt-1.1.38::gentoo
dev-libs/libyaml-0.2.5::gentoo
dev-libs/mpc-1.3.1::gentoo
dev-libs/mpfr-4.2.0_p9::gentoo
dev-libs/nettle-3.9.1::gentoo
dev-libs/npth-1.6-r1::gentoo
dev-libs/openssl-1.1.1w::gentoo
dev-libs/popt-1.19::gentoo
dev-lua/lpeg-1.0.2-r101::gentoo
dev-lua/lua-bit32-5.3.5.1-r1::gentoo
dev-lua/lua-term-0.7-r2::gentoo
dev-lua/luafilesystem-1.8.0-r101::gentoo
dev-lua/luajson-1.3.4::gentoo
dev-lua/luaposix-36.1::gentoo
dev-perl/Authen-SASL-2.160.0-r2::gentoo
dev-perl/Digest-HMAC-1.40.0::gentoo
dev-perl/Error-0.170.290::gentoo
dev-perl/ExtUtils-CChecker-0.110.0::gentoo
dev-perl/IO-Socket-SSL-2.83.0::gentoo
dev-perl/Locale-gettext-1.70.0-r1::gentoo
dev-perl/MailTools-2.210.0::gentoo
dev-perl/MIME-Charset-1.13.1::gentoo
dev-perl/Module-Build-0.423.100::gentoo
dev-perl/Mozilla-CA-20999999-r1::gentoo
dev-perl/Net-SSLeay-1.920.0-r1::gentoo
dev-perl/Pod-Parser-1.630.0-r1::gentoo
dev-perl/SGMLSpm-1.1-r2::gentoo
dev-perl/Syntax-Keyword-Try-0.270.0::gentoo
dev-perl/TermReadKey-2.380.0-r1::gentoo
dev-perl/Text-CharWidth-0.40.0-r2::gentoo
dev-perl/Text-WrapI18N-0.60.0-r2::gentoo
dev-perl/TimeDate-2.330.0-r1::gentoo
dev-perl/Unicode-LineBreak-2019.1.0::gentoo
dev-perl/XS-Parse-Keyword-0.330.0::gentoo
dev-perl/YAML-Tiny-1.730.0-r1::gentoo
dev-python/arrow-1.2.3::gentoo
dev-python/attrs-23.1.0::gentoo
dev-python/autocommand-2.2.2::gentoo
dev-python/calver-2022.06.26::gentoo
dev-python/certifi-3021.3.16-r3::gentoo
dev-python/cffi-1.15.1-r3::gentoo
dev-python/colorama-0.4.6::gentoo
dev-python/cryptography-41.0.1::gentoo
dev-python/cython-0.29.35::gentoo
dev-python/editables-0.3::gentoo
dev-python/ensurepip-pip-23.1.2::gentoo
dev-python/ensurepip-setuptools-67.8.0::gentoo
dev-python/ensurepip-wheels-100::gentoo
dev-python/flit-core-3.9.0::gentoo
dev-python/fqdn-1.5.1-r2::gentoo
dev-python/gentoo-common-1::gentoo
dev-python/gitdb-4.0.10::gentoo
dev-python/GitPython-3.1.31::gentoo
dev-python/gpep517-13::gentoo
dev-python/hatch-fancy-pypi-readme-23.1.0::gentoo
dev-python/hatch-vcs-0.3.0::gentoo
dev-python/hatchling-1.17.1::gentoo
dev-python/idna-3.4::gentoo
dev-python/importlib-metadata-6.6.0::gentoo
dev-python/inflect-6.0.4::gentoo
dev-python/iniconfig-2.0.0::gentoo
dev-python/installer-0.7.0::gentoo
dev-python/isoduration-20.11.0-r1::gentoo
dev-python/jaraco-classes-3.2.3::gentoo
dev-python/jaraco-context-4.3.0::gentoo
dev-python/jaraco-functools-3.7.0::gentoo
dev-python/jaraco-text-3.11.1::gentoo
dev-python/jeepney-0.8.0::gentoo
dev-python/jinja-3.1.2::gentoo
dev-python/jsonpointer-2.3::gentoo
dev-python/jsonschema-4.17.3::gentoo
dev-python/keyring-23.13.1-r1::gentoo
dev-python/lark-1.1.5::gentoo
dev-python/linkify-it-py-2.0.2::gentoo
dev-python/lxml-4.9.2-r1::gentoo
dev-python/markdown-it-py-3.0.0::gentoo
dev-python/markupsafe-2.1.3::gentoo
dev-python/mdurl-0.1.2::gentoo
dev-python/more-itertools-9.1.0::gentoo
dev-python/nspektr-0.4.0::gentoo
dev-python/ordered-set-4.1.0::gentoo
dev-python/packaging-23.1::gentoo
dev-python/pathspec-0.11.1::gentoo
dev-python/pip-23.1.2::gentoo
dev-python/platformdirs-3.5.1::gentoo
dev-python/pluggy-1.0.0-r2::gentoo
dev-python/ply-3.11-r2::gentoo
dev-python/poetry-core-1.6.1::gentoo
dev-python/pycodestyle-2.10.0::gentoo
dev-python/pycparser-2.21-r2::gentoo
dev-python/pydantic-1.10.9::gentoo
dev-python/pygments-2.15.1::gentoo
dev-python/pyparsing-3.0.9::gentoo
dev-python/pyrsistent-0.19.3::gentoo
dev-python/pytest-7.3.1-r2::gentoo
dev-python/python-dateutil-2.8.2-r1::gentoo
dev-python/pyyaml-6.0-r1::gentoo
dev-python/regex-2023.6.3::gentoo
dev-python/rfc3339-validator-0.1.4-r1::gentoo
dev-python/rfc3986-validator-0.1.1-r1::gentoo
dev-python/rfc3987-1.3.8-r2::gentoo
dev-python/rich-13.4.1::gentoo
dev-python/secretstorage-3.3.3::gentoo
dev-python/semantic-version-2.10.0::gentoo
dev-python/setuptools-67.8.0::gentoo
dev-python/setuptools-scm-7.1.0::gentoo
dev-python/six-1.16.0-r1::gentoo
dev-python/smmap-5.0.0-r1::gentoo
dev-python/strict-rfc3339-0.7-r2::gentoo
dev-python/tomli-2.0.1-r1::gentoo
dev-python/trove-classifiers-2023.5.24::gentoo
dev-python/typing-extensions-4.6.3::gentoo
dev-python/uc-micro-py-1.0.2::gentoo
dev-python/uri-template-1.2.0-r1::gentoo
dev-python/webcolors-1.13::gentoo
dev-python/wheel-0.40.0::gentoo
dev-python/zipp-3.15.0::gentoo
dev-util/direnv-2.32.2::eessi
dev-util/gperf-3.1-r1::gentoo
dev-util/hermes-2.9::gentoo
dev-util/patchelf-0.18.0::gentoo
dev-util/pkgconf-1.8.1::gentoo
dev-util/re2c-2.2::gentoo
dev-vcs/git-2.41.0::gentoo
media-fonts/dejavu-2.37::gentoo
media-fonts/liberation-fonts-2.1.5::gentoo
media-libs/fontconfig-2.14.2-r3::gentoo
media-libs/freetype-2.13.0::gentoo
media-libs/libpng-1.6.39::gentoo
net-dns/c-ares-1.19.1::gentoo
net-dns/libidn2-2.3.4::gentoo
net-libs/gnutls-3.8.0::gentoo
net-libs/libnsl-2.0.0-r1::gentoo
net-libs/libtirpc-1.3.3::gentoo
net-libs/nghttp2-1.52.0::gentoo
net-misc/curl-8.1.2::gentoo
net-misc/rsync-3.2.7-r2::gentoo
net-misc/wget-1.21.4::gentoo
perl-core/File-Temp-0.231.100::gentoo
sys-apps/acl-2.3.1-r2::gentoo
sys-apps/archspec-0.2.1::eessi
sys-apps/attr-2.5.1-r2::gentoo
sys-apps/baselayout-2.13-r1::gentoo
sys-apps/coreutils-9.3-r1::gentoo
sys-apps/dbus-1.15.6::gentoo
sys-apps/debianutils-5.7::gentoo
sys-apps/diffutils-3.10::gentoo
sys-apps/file-5.44-r3::gentoo
sys-apps/findutils-4.9.0-r2::gentoo
sys-apps/gawk-5.2.2::gentoo
sys-apps/gentoo-functions-0.19::gentoo
sys-apps/grep-3.11::gentoo
sys-apps/groff-1.22.4::gentoo
sys-apps/help2man-1.49.3::gentoo
sys-apps/kmod-30-r1::gentoo
sys-apps/less-633::gentoo
sys-apps/locale-gen-2.23-r1::gentoo
sys-apps/lsb-release-3.2::gentoo
sys-apps/man-db-2.11.2::gentoo
sys-apps/miscfiles-1.5-r4::gentoo
sys-apps/net-tools-2.10::gentoo
sys-apps/portage-3.0.48.1::gentoo
sys-apps/sandbox-2.30-r1::gentoo
sys-apps/sed-4.9::gentoo
sys-apps/systemd-utils-253.5::gentoo
sys-apps/texinfo-7.0.3::gentoo
sys-apps/util-linux-2.38.1-r2::gentoo
sys-apps/which-2.21::gentoo
sys-auth/pambase-20220214::gentoo
sys-auth/passwdqc-2.0.2-r1::gentoo
sys-cluster/lmod-8.7.23::gentoo
sys-cluster/rdma-core-45.0::gentoo
sys-devel/bc-1.07.1-r6::gentoo
sys-devel/binutils-2.40-r5::gentoo
sys-devel/binutils-config-5.5::gentoo
sys-devel/bison-3.8.2-r2::gentoo
sys-devel/flex-2.6.4-r6::gentoo
sys-devel/gcc-10.4.1_p20230517::gentoo
sys-devel/gcc-config-2.11::gentoo
sys-devel/gettext-0.21.1::gentoo
sys-devel/gnuconfig-20230121::gentoo
sys-devel/m4-1.4.19-r2::gentoo
sys-devel/patch-2.7.6-r5::gentoo
sys-fs/e2fsprogs-1.47.0-r1::gentoo
sys-fs/udev-init-scripts-35::gentoo
sys-kernel/installkernel-7::gentoo
sys-kernel/linux-headers-6.3::gentoo
sys-libs/gdbm-1.23::gentoo
sys-libs/glibc-2.37-r10::gentoo
sys-libs/libcap-2.69::gentoo
sys-libs/libseccomp-2.5.4::gentoo
sys-libs/libxcrypt-4.4.35::gentoo
sys-libs/ncurses-6.4_p20230401::gentoo
sys-libs/pam-1.5.3::gentoo
sys-libs/readline-8.2_p1::gentoo
sys-libs/timezone-data-2023c::gentoo
sys-libs/zlib-1.2.13-r1::gentoo
sys-process/numactl-2.0.16::gentoo
sys-process/procps-3.3.17-r1::gentoo
sys-process/psmisc-23.6::gentoo
virtual/acl-0-r2::gentoo
virtual/editor-0-r5::gentoo
virtual/libc-1-r1::gentoo
virtual/libcrypt-2-r1::gentoo
virtual/libiconv-0-r2::gentoo
virtual/libintl-0-r2::gentoo
virtual/libudev-232-r7::gentoo
virtual/man-0-r4::gentoo
virtual/os-headers-0-r2::gentoo
virtual/package-manager-1::gentoo
virtual/pager-0-r1::gentoo
virtual/perl-Carp-1.520.0-r2::gentoo
virtual/perl-CPAN-2.330.0::gentoo
virtual/perl-CPAN-Meta-2.150.10-r7::gentoo
virtual/perl-CPAN-Meta-YAML-0.18.0-r9::gentoo
virtual/perl-Data-Dumper-2.184.0::gentoo
virtual/perl-Digest-MD5-2.580.0-r1::gentoo
virtual/perl-Digest-SHA-6.20.0-r3::gentoo
virtual/perl-Encode-3.170.0::gentoo
virtual/perl-Exporter-5.770.0-r1::gentoo
virtual/perl-ExtUtils-CBuilder-0.280.236-r1::gentoo
virtual/perl-ExtUtils-Install-2.200.0-r1::gentoo
virtual/perl-ExtUtils-MakeMaker-7.640.0::gentoo
virtual/perl-ExtUtils-Manifest-1.730.0-r2::gentoo
virtual/perl-ExtUtils-ParseXS-3.450.0::gentoo
virtual/perl-File-Spec-3.840.0::gentoo
virtual/perl-File-Temp-0.231.100::gentoo
virtual/perl-Getopt-Long-2.520.0-r1::gentoo
virtual/perl-IO-1.500.0::gentoo
virtual/perl-JSON-PP-4.70.0::gentoo
virtual/perl-libnet-3.140.0::gentoo
virtual/perl-MIME-Base64-3.160.0-r1::gentoo
virtual/perl-Module-Metadata-1.0.37-r3::gentoo
virtual/perl-Parse-CPAN-Meta-2.150.10-r7::gentoo
virtual/perl-Perl-OSType-1.10.0-r7::gentoo
virtual/perl-podlators-4.140.0-r3::gentoo
virtual/perl-Scalar-List-Utils-1.620.0::gentoo
virtual/perl-Test-Harness-3.440.0-r1::gentoo
virtual/perl-Text-ParseWords-3.310.0-r1::gentoo
virtual/perl-version-0.992.900-r1::gentoo
virtual/pkgconfig-2-r1::gentoo
virtual/tmpfiles-0-r3::gentoo
virtual/ttf-fonts-1-r2::gentoo
virtual/udev-217-r5::gentoo
x11-base/xcb-proto-1.15.2::gentoo
x11-base/xorg-proto-2023.1::gentoo
x11-libs/libICE-1.1.1-r1::gentoo
x11-libs/libSM-1.2.4::gentoo
x11-libs/libX11-1.8.5::gentoo
x11-libs/libXau-1.0.11::gentoo
x11-libs/libxcb-1.15-r1::gentoo
x11-libs/libXdmcp-1.1.4-r2::gentoo
x11-libs/libXt-1.3.0::gentoo
x11-libs/xtrans-1.5.0::gentoo
x11-misc/compose-tables-1.8.5::gentoo

  ```
</details>